### PR TITLE
Update landing start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ export default tseslint.config({
 })
 ```
 
+## Running the landing page
+
+To start the landing application, execute the following command from the project root:
+
+```bash
+pnpm dev:landing
+```
+
+Running `pnpm dev` inside `apps/landing` does not work because that folder lacks its own `package.json`. The `dev:landing` script runs Vite with the configuration defined in `apps/landing/vite.config.ts`.
+
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:app": "vite --config apps/app/vite.config.ts",
+    "dev:landing": "vite --config apps/landing/vite.config.ts",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"


### PR DESCRIPTION
## Summary
- add `dev:landing` and `dev:app` scripts
- document how to start the landing application

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.11.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_685a8f323e8c832c9a7e1f4d3ee61288